### PR TITLE
ENUM 클래스 외부로 추출

### DIFF
--- a/back/src/main/java/com/studypot/back/applications/ProfileService.java
+++ b/back/src/main/java/com/studypot/back/applications/ProfileService.java
@@ -1,9 +1,9 @@
 package com.studypot.back.applications;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.studypot.back.domain.Category;
-import com.studypot.back.domain.Category.CategoryName;
-import com.studypot.back.domain.CategoryRepository;
+import com.studypot.back.domain.UserCategory;
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.UserCategoryRepository;
 import com.studypot.back.domain.User;
 import com.studypot.back.domain.UserRepository;
 import com.studypot.back.dto.CategoryResponseDto;
@@ -29,7 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileService {
 
   private final UserRepository userRepository;
-  private final CategoryRepository categoryRepository;
+  private final UserCategoryRepository userCategoryRepository;
   private final S3Service s3Service;
 
   public ProfileResponseDto getProfile(Long userId) {
@@ -49,13 +49,13 @@ public class ProfileService {
     String fileUrl = saveImage(updateProfileRequestDto.getImage(), user);
 
     //TODO: 딜리트 말고 다른 방안 찾아보기
-    categoryRepository.deleteAllByUserId(userId);
+    userCategoryRepository.deleteAllByUserId(userId);
 
     return updateUser(user, updateProfileRequestDto, fileUrl);
 
   }
 
-  private List<CategoryResponseDto> userCategoryList(List<Category> categories) {
+  private List<CategoryResponseDto> userCategoryList(List<UserCategory> categories) {
     return categories.stream()
         .map(category -> new CategoryResponseDto(category.getCategory()))
         .collect(Collectors.toList());
@@ -87,16 +87,16 @@ public class ProfileService {
   }
 
   private void updateCategories(List<CategoryName> categories, User user) {
-    Set<Category> categorySet = new HashSet<>();
+    Set<UserCategory> userCategorySet = new HashSet<>();
     for (CategoryName categoryName : categories) {
 
-      categorySet.add(
-          Category.builder()
+      userCategorySet.add(
+          UserCategory.builder()
               .user(user)
               .category(categoryName)
               .build());
     }
-    categoryRepository.saveAll(categorySet);
+    userCategoryRepository.saveAll(userCategorySet);
   }
 
   private String uploadToS3(MultipartFile multipartFile) throws IOException {

--- a/back/src/main/java/com/studypot/back/applications/UserService.java
+++ b/back/src/main/java/com/studypot/back/applications/UserService.java
@@ -1,8 +1,8 @@
 package com.studypot.back.applications;
 
-import com.studypot.back.domain.Category;
-import com.studypot.back.domain.Category.CategoryName;
-import com.studypot.back.domain.CategoryRepository;
+import com.studypot.back.domain.UserCategory;
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.UserCategoryRepository;
 import com.studypot.back.domain.User;
 import com.studypot.back.domain.UserRepository;
 import com.studypot.back.dto.user.UserSignupRequestDto;
@@ -22,7 +22,7 @@ public class UserService {
 
   private final PasswordEncoder passwordEncoder;
 
-  private final CategoryRepository categoryRepository;
+  private final UserCategoryRepository userCategoryRepository;
 
 
   public User registerUser(UserSignupRequestDto signupRequestDto) {
@@ -54,17 +54,17 @@ public class UserService {
   }
 
   private void saveCategories(List<CategoryName> categories, User user) {
-    Set<Category> categorySet = new HashSet<>();
+    Set<UserCategory> userCategorySet = new HashSet<>();
     for (CategoryName categoryName : categories) {
 
-      categorySet.add(
-          Category.builder()
+      userCategorySet.add(
+          UserCategory.builder()
               .user(user)
               .category(categoryName)
               .build());
     }
 
-    categoryRepository.saveAll(categorySet);
+    userCategoryRepository.saveAll(userCategorySet);
   }
 
 }

--- a/back/src/main/java/com/studypot/back/domain/CategoryName.java
+++ b/back/src/main/java/com/studypot/back/domain/CategoryName.java
@@ -1,0 +1,16 @@
+package com.studypot.back.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryName {
+
+  IT("IT"),
+  CS("CS"),
+  INTERVIEW("면접");
+
+  private final String value;
+
+}

--- a/back/src/main/java/com/studypot/back/domain/User.java
+++ b/back/src/main/java/com/studypot/back/domain/User.java
@@ -43,7 +43,7 @@ public class User {
   private String location;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-  private List<Category> categories;
+  private List<UserCategory> categories;
 
   @Setter
   private String introduction;

--- a/back/src/main/java/com/studypot/back/domain/UserCategory.java
+++ b/back/src/main/java/com/studypot/back/domain/UserCategory.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Builder
 @Getter
-public class Category {
+public class UserCategory {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,18 +30,6 @@ public class Category {
   @Setter
   @Enumerated(EnumType.STRING)
   private CategoryName category;
-
-  @Getter
-  @AllArgsConstructor
-  public enum CategoryName {
-
-    IT("IT"),
-    CS("CS"),
-    INTERVIEW("면접");
-
-    private final String value;
-
-  }
 
 
 }

--- a/back/src/main/java/com/studypot/back/domain/UserCategoryRepository.java
+++ b/back/src/main/java/com/studypot/back/domain/UserCategoryRepository.java
@@ -3,7 +3,7 @@ package com.studypot.back.domain;
 import javax.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
 
   //TODO: Transactional 분석
   @Transactional

--- a/back/src/main/java/com/studypot/back/dto/CategoryResponseDto.java
+++ b/back/src/main/java/com/studypot/back/dto/CategoryResponseDto.java
@@ -1,6 +1,6 @@
 package com.studypot.back.dto;
 
-import com.studypot.back.domain.Category.CategoryName;
+import com.studypot.back.domain.CategoryName;
 import lombok.Getter;
 
 @Getter

--- a/back/src/main/java/com/studypot/back/dto/profile/UpdateProfileRequestDto.java
+++ b/back/src/main/java/com/studypot/back/dto/profile/UpdateProfileRequestDto.java
@@ -1,6 +1,6 @@
 package com.studypot.back.dto.profile;
 
-import com.studypot.back.domain.Category.CategoryName;
+import com.studypot.back.domain.CategoryName;
 import java.util.List;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;

--- a/back/src/main/java/com/studypot/back/dto/user/UserSignupRequestDto.java
+++ b/back/src/main/java/com/studypot/back/dto/user/UserSignupRequestDto.java
@@ -1,6 +1,6 @@
 package com.studypot.back.dto.user;
 
-import com.studypot.back.domain.Category.CategoryName;
+import com.studypot.back.domain.CategoryName;
 import java.util.List;
 import lombok.Data;
 

--- a/back/src/main/java/com/studypot/back/interfaces/CategoryController.java
+++ b/back/src/main/java/com/studypot/back/interfaces/CategoryController.java
@@ -1,6 +1,6 @@
 package com.studypot.back.interfaces;
 
-import com.studypot.back.domain.Category.CategoryName;
+import com.studypot.back.domain.CategoryName;
 import com.studypot.back.dto.CategoryResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;

--- a/back/src/test/java/com/studypot/back/applications/ProfileServiceTest.java
+++ b/back/src/test/java/com/studypot/back/applications/ProfileServiceTest.java
@@ -2,7 +2,7 @@ package com.studypot.back.applications;
 
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import com.studypot.back.domain.CategoryRepository;
+import com.studypot.back.domain.UserCategoryRepository;
 import com.studypot.back.domain.User;
 import com.studypot.back.domain.UserRepository;
 import com.studypot.back.s3.S3Service;
@@ -24,7 +24,7 @@ class ProfileServiceTest {
   private S3Service s3Service;
 
   @Mock
-  private CategoryRepository categoryRepository;
+  private UserCategoryRepository userCategoryRepository;
 
   private User mockUser;
 

--- a/back/src/test/java/com/studypot/back/applications/UserServiceTest.java
+++ b/back/src/test/java/com/studypot/back/applications/UserServiceTest.java
@@ -7,8 +7,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import com.studypot.back.domain.Category.CategoryName;
-import com.studypot.back.domain.CategoryRepository;
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.UserCategoryRepository;
 import com.studypot.back.domain.User;
 import com.studypot.back.domain.UserRepository;
 import com.studypot.back.dto.user.UserSignupRequestDto;
@@ -30,12 +30,12 @@ class UserServiceTest {
   private PasswordEncoder passwordEncoder;
 
   @Mock
-  private CategoryRepository categoryRepository;
+  private UserCategoryRepository userCategoryRepository;
 
   @BeforeEach
   public void setUp() {
     openMocks(this);
-    userService = new UserService(userRepository, passwordEncoder, categoryRepository);
+    userService = new UserService(userRepository, passwordEncoder, userCategoryRepository);
   }
 
   @Test

--- a/back/src/test/java/com/studypot/back/domain/UserCategoryTest.java
+++ b/back/src/test/java/com/studypot/back/domain/UserCategoryTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import com.studypot.back.domain.Category.CategoryName;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-public class CategoryTest {
+public class UserCategoryTest {
 
   @BeforeEach
   public void setUp() {


### PR DESCRIPTION
- Category 클래스의 CategoryName enum 클래스의 하나의 외부 클래스로 추출
기존 Category 클래스는 user에 관한 정보를 담고 있기때문에 스터디에 관한 정보를 추가하기에는 구조적으로, 논리적으로 맞지 않았습니다. 그래서 Category 엔터티를UserCategory로 이름을 바꾸고 내부에 있던 enum 클래스를 외부 클래스로 만들었습니다.