### PR TITLE
:wrench: STUDYPOT-43 open-in-view 로그 해결

### DIFF
--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+    open-in-view: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${mysql.hostServer}:3306/${mysql.databaseName}?serverTimezone=UTC&characterEncoding=UTF-8&validationQuery="select 1"


### PR DESCRIPTION
## open-in-view 경고 로그
- 설정 파일에 open-in-view: true로 바꿔 해결
- 해당 로그가 발생하는 소스 코드를 찾아본 결과, open-in-view가 null 일 시 default가 true라는 결 알려준다는 것을 보고 open-in-view가 true라고 명시함. 
- open-in-view가 true일 때 발생하는 서버의 효율성 문제가 크지 않다고 보고 true로 유지.
- false로 돌릴 때에는 연관관계에 있는 jpa 코드들에 대해 모두 확인해야 함. EAGER로 바꿀 지 @Transactional을 붙일 지 확인해야 함. 
- open-in-view: true가 추후 메모리 상 비효율적인 측면이 증가될 때 false로 바꾸는 작업이 필요함.