### PR TITLE
스터디 생성 API

### DIFF
--- a/back/src/main/java/com/studypot/back/applications/StudyService.java
+++ b/back/src/main/java/com/studypot/back/applications/StudyService.java
@@ -25,7 +25,7 @@ public class StudyService {
     String thumbnailUrl = createImageUrlOrNull(studyCreateRequestDto.getThumbnail());
 
     Study study = studyCreateRequestDto.buildStudy(userId, thumbnailUrl);
-    study.createStudyMemberList(userId);
+    study.addToStudyMemberList(userId);
     study.createStudyCategoryList(studyCreateRequestDto.getCategories());
 
     return studyRepository.save(study);

--- a/back/src/main/java/com/studypot/back/applications/StudyService.java
+++ b/back/src/main/java/com/studypot/back/applications/StudyService.java
@@ -1,0 +1,94 @@
+package com.studypot.back.applications;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.Study;
+import com.studypot.back.domain.StudyCategory;
+import com.studypot.back.domain.StudyCategoryRepository;
+import com.studypot.back.domain.StudyMember;
+import com.studypot.back.domain.StudyMemberRepository;
+import com.studypot.back.domain.StudyRepository;
+import com.studypot.back.domain.User;
+import com.studypot.back.domain.UserRepository;
+import com.studypot.back.dto.study.StudyCreateRequestDto;
+import com.studypot.back.exceptions.UserNotFoundException;
+import com.studypot.back.s3.S3Service;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class StudyService {
+
+  private final StudyRepository studyRepository;
+
+  private final UserRepository userRepository;
+
+  private final StudyMemberRepository studyMemberRepository;
+
+  private final StudyCategoryRepository studyCategoryRepository;
+
+  private final S3Service s3Service;
+
+
+  public Study addStudy(Long userId, StudyCreateRequestDto studyCreateRequestDto) throws IOException {
+
+    String thumbnailUrl;
+    if (studyCreateRequestDto.getThumbnail() != null) {
+      thumbnailUrl = uploadToS3(studyCreateRequestDto.getThumbnail());
+    } else {
+      thumbnailUrl = null;
+    }
+
+    Study savedStudy = studyRepository.save(studyCreateRequestDto.studyBuilder(userId, thumbnailUrl));
+
+    User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    studyMemberRepository.save(StudyMember.builder().study(savedStudy).user(user).build());
+    updateCategories(studyCreateRequestDto.getCategories(), savedStudy);
+
+    return savedStudy;
+
+  }
+
+  private void updateCategories(List<CategoryName> categories, Study study) {
+    Set<StudyCategory> studyCategorySet = new HashSet<>();
+    for (CategoryName categoryName : categories) {
+
+      studyCategorySet.add(
+          StudyCategory.builder()
+              .study(study)
+              .category(categoryName)
+              .build());
+    }
+    studyCategoryRepository.saveAll(studyCategorySet);
+  }
+
+  private String uploadToS3(MultipartFile multipartFile) throws IOException {
+    String fileName = createUUIDFileName(multipartFile.getOriginalFilename());
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentType(multipartFile.getContentType());
+
+    InputStream inputStream = multipartFile.getInputStream();
+
+    return s3Service.uploadFile(fileName, inputStream, objectMetadata);
+  }
+
+  private String createUUIDFileName(String name) {
+    return UUID.randomUUID().toString().concat(fileNameExtension(name));
+  }
+
+  private String fileNameExtension(String name) {
+    try {
+      return name.substring(name.lastIndexOf("."));
+    } catch (StringIndexOutOfBoundsException e) {
+      throw new IllegalArgumentException(String.format("not supported file: %s", name));
+    }
+  }
+}

--- a/back/src/main/java/com/studypot/back/domain/Study.java
+++ b/back/src/main/java/com/studypot/back/domain/Study.java
@@ -59,17 +59,23 @@ public class Study {
   private Long leaderUserId;
 
   @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-  private final List<StudyMember> members = new ArrayList<>();
+  private List<StudyMember> members;
 
   @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-  private final List<StudyCategory> categories = new ArrayList<>();
+  private List<StudyCategory> categories;
 
-  public void createStudyMemberList(Long userId) {
+  public void addToStudyMemberList(Long userId) {
+    if (members == null) {
+      this.members = new ArrayList<>();
+    }
+
     this.members.add(StudyMember.builder().study(this).userId(userId).build());
   }
 
-  public void createStudyCategoryList(List<CategoryName> categories) {
-    categories.stream()
+  public void createStudyCategoryList(List<CategoryName> categoryNames) {
+    this.categories = new ArrayList<>();
+
+    categoryNames.stream()
         .map(categoryName -> StudyCategory.builder()
             .study(this)
             .category(categoryName)

--- a/back/src/main/java/com/studypot/back/domain/Study.java
+++ b/back/src/main/java/com/studypot/back/domain/Study.java
@@ -1,6 +1,7 @@
 package com.studypot.back.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -58,9 +59,21 @@ public class Study {
   private Long leaderUserId;
 
   @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-  private List<StudyMember> members;
+  private final List<StudyMember> members = new ArrayList<>();
 
   @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-  private List<StudyCategory> categories;
+  private final List<StudyCategory> categories = new ArrayList<>();
 
+  public void createStudyMemberList(Long userId) {
+    this.members.add(StudyMember.builder().study(this).userId(userId).build());
+  }
+
+  public void createStudyCategoryList(List<CategoryName> categories) {
+    categories.stream()
+        .map(categoryName -> StudyCategory.builder()
+            .study(this)
+            .category(categoryName)
+            .build())
+        .forEach(this.categories::add);
+  }
 }

--- a/back/src/main/java/com/studypot/back/domain/StudyMember.java
+++ b/back/src/main/java/com/studypot/back/domain/StudyMember.java
@@ -30,8 +30,7 @@ public class StudyMember {
   @ManyToOne
   private Study study;
 
-  @ManyToOne
-  private User user;
+  private Long userId;
 
   @CreatedDate
   private LocalDateTime createdAt;

--- a/back/src/main/java/com/studypot/back/domain/User.java
+++ b/back/src/main/java/com/studypot/back/domain/User.java
@@ -1,14 +1,12 @@
 package com.studypot.back.domain;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,13 +51,4 @@ public class User {
   @Setter
   private String imageUrl;
 
-  @Getter(AccessLevel.PROTECTED)
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-  private List<StudyMember> studyMemberList;
-
-  public List<Study> getParticipateStudyList() {
-    return this.studyMemberList.stream()
-        .map(StudyMember::getStudy)
-        .collect(Collectors.toList());
-  }
 }

--- a/back/src/main/java/com/studypot/back/domain/User.java
+++ b/back/src/main/java/com/studypot/back/domain/User.java
@@ -1,12 +1,14 @@
 package com.studypot.back.domain;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,7 +53,13 @@ public class User {
   @Setter
   private String imageUrl;
 
+  @Getter(AccessLevel.PROTECTED)
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-  private List<StudyMember> participateStudyList;
+  private List<StudyMember> studyMemberList;
 
+  public List<Study> getParticipateStudyList() {
+    return this.studyMemberList.stream()
+        .map(StudyMember::getStudy)
+        .collect(Collectors.toList());
+  }
 }

--- a/back/src/main/java/com/studypot/back/dto/study/StudyCreateRequestDto.java
+++ b/back/src/main/java/com/studypot/back/dto/study/StudyCreateRequestDto.java
@@ -1,0 +1,42 @@
+package com.studypot.back.dto.study;
+
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.MeetingType;
+import com.studypot.back.domain.Study;
+import com.studypot.back.domain.StudyStatus;
+import java.util.List;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class StudyCreateRequestDto {
+
+  private List<CategoryName> categories;
+
+  private String locatedAt;
+
+  private String title;
+
+  private String content;
+
+  private Integer maxStudyNumber;
+
+  private MeetingType meetingType;
+
+  private StudyStatus status;
+
+  private MultipartFile thumbnail;
+
+  public Study studyBuilder(Long userId, String thumbnailUrl) {
+    return Study.builder()
+        .locatedAt(this.locatedAt)
+        .title(this.title)
+        .content(this.content)
+        .maxStudyNumber(this.maxStudyNumber)
+        .meetingType(this.meetingType)
+        .status(this.status)
+        .thumbnailUrl(thumbnailUrl)
+        .leaderUserId(userId)
+        .build();
+  }
+}

--- a/back/src/main/java/com/studypot/back/dto/study/StudyCreateRequestDto.java
+++ b/back/src/main/java/com/studypot/back/dto/study/StudyCreateRequestDto.java
@@ -27,7 +27,7 @@ public class StudyCreateRequestDto {
 
   private MultipartFile thumbnail;
 
-  public Study studyBuilder(Long userId, String thumbnailUrl) {
+  public Study buildStudy(Long userId, String thumbnailUrl) {
     return Study.builder()
         .locatedAt(this.locatedAt)
         .title(this.title)

--- a/back/src/main/java/com/studypot/back/interfaces/StudyController.java
+++ b/back/src/main/java/com/studypot/back/interfaces/StudyController.java
@@ -1,0 +1,31 @@
+package com.studypot.back.interfaces;
+
+import com.studypot.back.applications.StudyService;
+import com.studypot.back.auth.UserId;
+import com.studypot.back.dto.study.StudyCreateRequestDto;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StudyController {
+
+  private final StudyService studyService;
+
+  @PostMapping("/study")
+  @ResponseStatus(HttpStatus.CREATED)
+  public void addStudy(
+      @UserId Long userId,
+      StudyCreateRequestDto studyCreateRequestDto
+  ) throws IOException {
+
+    studyService.addStudy(userId, studyCreateRequestDto);
+
+  }
+
+
+}

--- a/back/src/main/java/com/studypot/back/interfaces/StudyController.java
+++ b/back/src/main/java/com/studypot/back/interfaces/StudyController.java
@@ -22,10 +22,6 @@ public class StudyController {
       @UserId Long userId,
       StudyCreateRequestDto studyCreateRequestDto
   ) throws IOException {
-
     studyService.addStudy(userId, studyCreateRequestDto);
-
   }
-
-
 }

--- a/back/src/test/java/com/studypot/back/applications/StudyServiceTest.java
+++ b/back/src/test/java/com/studypot/back/applications/StudyServiceTest.java
@@ -1,0 +1,72 @@
+package com.studypot.back.applications;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.studypot.back.domain.CategoryName;
+import com.studypot.back.domain.Study;
+import com.studypot.back.domain.StudyCategoryRepository;
+import com.studypot.back.domain.StudyMemberRepository;
+import com.studypot.back.domain.StudyRepository;
+import com.studypot.back.domain.StudyStatus;
+import com.studypot.back.domain.User;
+import com.studypot.back.domain.UserRepository;
+import com.studypot.back.dto.study.StudyCreateRequestDto;
+import com.studypot.back.s3.S3Service;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class StudyServiceTest {
+
+  private StudyService studyService;
+
+  @Mock
+  private StudyRepository studyRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private StudyMemberRepository studyMemberRepository;
+
+  @Mock
+  private StudyCategoryRepository studyCategoryRepository;
+
+  @Mock
+  private S3Service s3Service;
+
+  @BeforeEach
+  public void setUp() {
+    openMocks(this);
+    this.studyService = new StudyService(studyRepository, userRepository, studyMemberRepository, studyCategoryRepository, s3Service);
+  }
+
+  @Test
+  public void addStudy() throws IOException {
+    Long userId = 1L;
+    User mockUser = User.builder().build();
+    Study mockStudy = Study.builder().status(StudyStatus.OPEN).leaderUserId(userId).build();
+
+    given(studyRepository.save(any(Study.class))).willReturn(mockStudy);
+    given(userRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(mockUser));
+
+    List<CategoryName> categories = new ArrayList<>();
+    categories.add(CategoryName.INTERVIEW);
+    StudyCreateRequestDto studyCreateRequestDto = new StudyCreateRequestDto();
+    studyCreateRequestDto.setCategories(categories);
+
+    Study study = studyService.addStudy(userId, studyCreateRequestDto);
+
+    assertThat(study.getLeaderUserId(), is(1L));
+    assertThat(study.getStatus().getValue(), is("Open"));
+  }
+
+}

--- a/back/src/test/java/com/studypot/back/applications/StudyServiceTest.java
+++ b/back/src/test/java/com/studypot/back/applications/StudyServiceTest.java
@@ -8,8 +8,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.studypot.back.domain.CategoryName;
 import com.studypot.back.domain.Study;
-import com.studypot.back.domain.StudyCategoryRepository;
-import com.studypot.back.domain.StudyMemberRepository;
 import com.studypot.back.domain.StudyRepository;
 import com.studypot.back.domain.StudyStatus;
 import com.studypot.back.domain.User;
@@ -35,18 +33,12 @@ class StudyServiceTest {
   private UserRepository userRepository;
 
   @Mock
-  private StudyMemberRepository studyMemberRepository;
-
-  @Mock
-  private StudyCategoryRepository studyCategoryRepository;
-
-  @Mock
   private S3Service s3Service;
 
   @BeforeEach
   public void setUp() {
     openMocks(this);
-    this.studyService = new StudyService(studyRepository, userRepository, studyMemberRepository, studyCategoryRepository, s3Service);
+    this.studyService = new StudyService(studyRepository, s3Service);
   }
 
   @Test

--- a/back/src/test/java/com/studypot/back/interfaces/StudyControllerTest.java
+++ b/back/src/test/java/com/studypot/back/interfaces/StudyControllerTest.java
@@ -1,0 +1,55 @@
+package com.studypot.back.interfaces;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.studypot.back.applications.StudyService;
+import com.studypot.back.dto.study.StudyCreateRequestDto;
+import com.studypot.back.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(StudyController.class)
+@Import({JwtUtil.class})
+class StudyControllerTest {
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private JwtUtil jwtUtil;
+
+  private String token;
+
+  @MockBean
+  private StudyService studyService;
+
+  @BeforeEach
+  public void setUp() {
+    this.token = jwtUtil.createAccessToken(1L, "leo");
+  }
+
+  @Test
+  public void addStudy() throws Exception {
+
+    mvc.perform(post("/study")
+        .header("Authorization", "Bearer " + token)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .content("[\"title\", \"FIRST\"]"))
+        .andExpect(status().isCreated());
+
+    verify(studyService).addStudy(any(Long.class), any(StudyCreateRequestDto.class));
+  }
+
+}

--- a/back/src/test/java/com/studypot/back/interfaces/StudyControllerTest.java
+++ b/back/src/test/java/com/studypot/back/interfaces/StudyControllerTest.java
@@ -9,6 +9,7 @@ import com.studypot.back.applications.StudyService;
 import com.studypot.back.dto.study.StudyCreateRequestDto;
 import com.studypot.back.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,7 @@ class StudyControllerTest {
   }
 
   @Test
+  @DisplayName("스터디_생성_컨트롤러_테스트")
   public void addStudy() throws Exception {
 
     mvc.perform(post("/study")


### PR DESCRIPTION
1. Controller
- thumbnail image를 포함하기때문에 multipart/form-data로 데이터를 받음

2. Service
- 스터디 객체를 먼저 생성한 뒤 Join 관계의 주인 엔터티에 객체를 생성

3. Dto
- Dto에 스터디를 생성하는 메소드를 만들어 Service에서 getter 접근을 최소화

4. User
- 사용자가 참여한 스터디 조회를 Entity 내부에서 메소드로 구현하고 네이밍을 직관적으로 바꿈