### PR TITLE
STUDYPOT-137 마이페이지 스터디 목록

### DIFF
--- a/front/components/MyPageForm/index.tsx
+++ b/front/components/MyPageForm/index.tsx
@@ -1,8 +1,12 @@
 import React, { ReactElement } from "react";
 import { MypageFormBlock, StudyList, StudyListBox, StudyName, StudyDetail } from "./styles";
 import Profile from "@components/Profile";
+import { useSelector } from "react-redux";
+import { RootState } from "@lib/slices";
 
 const MyPageForm = (): ReactElement => {
+  const { user } = useSelector((state: RootState) => state.users);
+
   return (
     <MypageFormBlock>
       <Profile />
@@ -11,19 +15,31 @@ const MyPageForm = (): ReactElement => {
         <p>내스터디</p>
         <button>수정</button>
       </StudyList>
-      <StudyListBox>
-        <StudyName>디스코드 캠스터디</StudyName>
-        <StudyDetail>디스코드로 캠 켜고 같이 공부해요! 얼굴은 안나오고 손만 켤...</StudyDetail>
-      </StudyListBox>
+
+      {user.participatingStudyList &&
+        user.participatingStudyList.map((study: any) => {
+          return (
+            <StudyListBox key={study.studyId}>
+              <StudyName>{study.studyTitle}</StudyName>
+              <StudyDetail>{study.studyContent}</StudyDetail>
+            </StudyListBox>
+          );
+        })}
 
       <StudyList>
         <p>관심 스터디</p>
         <button>수정</button>
       </StudyList>
-      <StudyListBox>
-        <StudyName>디스코드 캠스터디</StudyName>
-        <StudyDetail>디스코드로 캠 켜고 같이 공부해요! 얼굴은 안나오고 손만 켤...</StudyDetail>
-      </StudyListBox>
+
+      {user.interestingStudyList &&
+        user.interestingStudyList.map((study: any) => {
+          return (
+            <StudyListBox key={study.studyId}>
+              <StudyName>{study.studyTitle}</StudyName>
+              <StudyDetail>{study.studyContent}</StudyDetail>
+            </StudyListBox>
+          );
+        })}
     </MypageFormBlock>
   );
 };

--- a/front/components/MyPageForm/index.tsx
+++ b/front/components/MyPageForm/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from "react";
 import { MypageFormBlock, StudyList, StudyListBox, StudyName, StudyDetail } from "./styles";
 import Profile from "@components/Profile";
 import { useSelector } from "react-redux";
-import { RootState } from "@lib/slices";
+import { RootState } from "@lib/store/configureStore";
 
 const MyPageForm = (): ReactElement => {
   const { user } = useSelector((state: RootState) => state.users);

--- a/front/components/MyPageForm/index.tsx
+++ b/front/components/MyPageForm/index.tsx
@@ -9,7 +9,7 @@ const MyPageForm = (): ReactElement => {
 
   return (
     <MypageFormBlock>
-      <Profile />
+      <Profile user={user} />
 
       <StudyList>
         <p>내스터디</p>

--- a/front/components/Profile/index.tsx
+++ b/front/components/Profile/index.tsx
@@ -19,17 +19,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { loadUserByToken } from "@lib/slices/UserSlice";
 import { RootState } from "@lib/store/configureStore";
 
-const Profile = (): ReactElement => {
-  const router = useRouter();
-  const dispatch = useDispatch();
-  const { user } = useSelector((state: RootState) => state.users);
-
-  useEffect(() => {
-    dispatch(loadUserByToken(null));
-  }, [dispatch]);
-  console.log(user);
-  console.log(user.image);
-
+const Profile = ({ user }: { user: any }): ReactElement => {
   return (
     <ProfileFormBlock>
       <DescBlock>

--- a/front/components/Profile/index.tsx
+++ b/front/components/Profile/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect } from "react";
+import React, { ReactElement } from "react";
 import {
   ProfileFormBlock,
   Location,
@@ -14,10 +14,6 @@ import Link from "next/link";
 import { LocationPin } from "@styled-icons/entypo/LocationPin";
 import { LightningFill } from "@styled-icons/bootstrap/LightningFill";
 import gravatar from "gravatar";
-import { useRouter } from "next/router";
-import { useDispatch, useSelector } from "react-redux";
-import { loadUserByToken } from "@lib/slices/UserSlice";
-import { RootState } from "@lib/store/configureStore";
 
 const Profile = ({ user }: { user: any }): ReactElement => {
   return (

--- a/front/lib/slices/UserSlice.ts
+++ b/front/lib/slices/UserSlice.ts
@@ -16,6 +16,8 @@ interface IloadUser {
   introduction: string;
   location: string;
   name: string;
+  participatingStudyList: Array<any>;
+  interestingStudyList: Array<any>;
   errorMessage: string;
 }
 interface signUpPayload {
@@ -47,6 +49,20 @@ const initialState: IUser = {
       {
         key: "",
         value: "",
+      },
+    ],
+    participatingStudyList: [
+      {
+        studyId: -1,
+        studyTitle: "",
+        studyContent: "",
+      },
+    ],
+    interestingStudyList: [
+      {
+        studyId: -1,
+        studyTitle: "",
+        studyContent: "",
       },
     ],
   },
@@ -205,6 +221,8 @@ export const userSlice = createSlice({
       state.user.image = payload.image;
       state.user.introduction = payload.introduction;
       state.user.location = payload.location;
+      state.user.participatingStudyList = payload.participatingStudyList;
+      state.user.interestingStudyList = payload.interestingStudyList;
       state.loadUserLoading = false;
       state.loadUserSuccess = true;
       state.loadUserError = false;


### PR DESCRIPTION
마이페이지에 내 스터디/관심 스터디 목록을 노출할 수 있게 수정했습니다.
JIRA [STUDYPOT-137](https://leokim.atlassian.net/browse/STUDYPOT-137)

테스트 결과
![image](https://user-images.githubusercontent.com/20104232/128626167-64ba5c61-8542-47a8-80f4-097f792723af.png)

@Gyumong @FromGoodEnoughYounGyeom 
1. `typings/db.ts`를 보면 유저 정보 타입을 `any` 로 사용 중인 것 같은데,
유저 정보에 대한 타입을 지정하려면 어떤 파일의 어떤 네이밍 룰을 가지고 작업하면 될지 확인해주시면 감사하겠습니다
2. 부끄러운 부탁이지만, 제가 화면을 그리는 것을 전혀 못해 테스트 결과에 나오는 네모 영역들의 사이즈를 좀 봐주시면 감사하겠습니다.

@leo0842 
1. 스터디 목록에서 공백의 스터디명, 설명들이 있습니다. 해당 데이터 확인 부탁드립니다.