### PR TITLE
🐛 리프레시 토큰을 이용한 토큰 갱신 실패시 로컬스토리지의 토큰 정보 삭제

### DIFF
--- a/front/utils/axios.ts
+++ b/front/utils/axios.ts
@@ -45,14 +45,25 @@ axiosWithToken.interceptors.response.use(
       console.log("토큰 만료");
       originalRequest._retry = true;
       const refreshToken = window.localStorage.getItem("refreshToken");
-      const { data } = await axios.get(`${backUrl}/refresh`, {
-        headers: {
-          Authorization: `Bearer ${refreshToken}`,
-        },
-      });
-      const { accessToken: newAccessToken, refreshToken: newRefreshToken } = data.data;
-      localStorage.setItem("accessToken", newAccessToken);
-      localStorage.setItem("refreshToken", newRefreshToken);
+
+      if (refreshToken) {
+        try {
+          const { data } = await axios.get(`${backUrl}/refresh`, {
+            headers: {
+              Authorization: `Bearer ${refreshToken}`,
+            },
+          });
+          const { accessToken: newAccessToken, refreshToken: newRefreshToken } = data.data;
+          localStorage.setItem("accessToken", newAccessToken);
+          localStorage.setItem("refreshToken", newRefreshToken);
+        } catch (e) {
+          console.warn("토큰을 삭제합니다.", e);
+          window.localStorage.removeItem("accessToken");
+          window.localStorage.removeItem("refreshToken");
+          return Promise.reject(e);
+        }
+      }
+
       return axios(originalRequest);
     }
     return Promise.reject(error);


### PR DESCRIPTION
리프레시 토큰을 이용한 토큰 갱신 실패시 오류가 발생해도 후속 처리가 없어서 기존 토큰을 삭제하도록 수정했습니다.