### PR TITLE
로그인하지 않은 사용자에 대한 좋아요 클릭 처리 수정 및 스터디 라우팅 변경

### DIFF
--- a/front/components/Header/index.tsx
+++ b/front/components/Header/index.tsx
@@ -27,7 +27,7 @@ const Header = () => {
 
         <MenuFrame>
           <MenuItem>
-            <Link href="/find">
+            <Link href="/study">
               <a>스터디찾기</a>
             </Link>
           </MenuItem>
@@ -58,7 +58,7 @@ const Header = () => {
       </Link>
       <MenuFrame>
         <MenuItem>
-          <Link href="/find">스터디찾기</Link>
+          <Link href="/study">스터디찾기</Link>
         </MenuItem>
         <MenuItem>
           <Link href="/recruit">스터디모집</Link>

--- a/front/components/RecruitForm/index.tsx
+++ b/front/components/RecruitForm/index.tsx
@@ -59,7 +59,7 @@ const RecruitForm = (): ReactElement => {
 
   useEffect(() => {
     if (!MakeStudyLoading && MakeStudySuccess) {
-      router.push("/find");
+      router.push("/study");
     }
   }, [MakeStudyLoading, MakeStudySuccess]);
 

--- a/front/components/StudyCard/index.tsx
+++ b/front/components/StudyCard/index.tsx
@@ -23,6 +23,7 @@ import { useDispatch } from "react-redux";
 import { useCallback } from "react";
 import { contentArray } from "@lib/slices/StudySlice";
 import { popModal } from "@lib/slices/ModalSlice";
+import { useRouter } from "next/router";
 interface StudyCardProps {
   studyId: number;
   study: contentArray;
@@ -34,6 +35,7 @@ const icon = {
 };
 
 const StudyCard: React.FC<StudyCardProps> = ({ studyId, study }) => {
+  const router = useRouter();
   const dispatch = useDispatch();
   const exampleOnClick = useCallback(() => {
     dispatch(popModal(null));
@@ -42,6 +44,7 @@ const StudyCard: React.FC<StudyCardProps> = ({ studyId, study }) => {
         studyId: studyId,
       }),
     );
+    router.push(`/study/${studyId}`);
   }, [dispatch]);
 
   const formatDate = (date: Date) => {

--- a/front/components/common/Modal.tsx
+++ b/front/components/common/Modal.tsx
@@ -6,9 +6,11 @@ import { RootState } from "@lib/store/configureStore";
 import { deleteModal } from "@lib/slices/ModalSlice";
 
 import StudyModal from "@components/StudyModal";
+import { useRouter } from "next/router";
 
 const Modal: React.FC = () => {
   const [isBrowser, setIsBrowser] = useState(false);
+  const router = useRouter();
   const dispatch = useDispatch();
   const { show } = useSelector((state: RootState) => state.modal);
   const { singleStudy } = useSelector((state: RootState) => state.study);
@@ -19,6 +21,7 @@ const Modal: React.FC = () => {
   const handleCloseClick = (e: any) => {
     e.preventDefault();
     dispatch(deleteModal());
+    router.push("/study");
   };
 
   const modalContent = show ? (

--- a/front/pages/study/[[...studyId]].tsx
+++ b/front/pages/study/[[...studyId]].tsx
@@ -1,30 +1,26 @@
-import React, { ReactElement, useEffect } from "react";
+import { ReactElement, useEffect } from "react";
 import Header from "@components/Header";
 import { StudyCardContainer } from "@components/FindStudy/styles";
 import { GridBox } from "@components/FindStudy/styles";
 import StudyCard from "@components/StudyCard";
 import MainSelect from "@components/MainSelect";
 import { useDispatch, useSelector } from "react-redux";
-import { clearState, contentArray, LoadStudy, clearStudy } from "@lib/slices/StudySlice";
-import { RootState, AppThunkDispatch } from "@lib/store/configureStore";
-import { useCallback, useMemo } from "react";
+import { clearState, contentArray, LoadStudy, clearStudy, LoadOneStudy } from "@lib/slices/StudySlice";
+import { RootState } from "@lib/store/configureStore";
+import { useMemo } from "react";
 import { loadUserByToken } from "@lib/slices/UserSlice";
 import _ from "lodash";
 import Modal from "@components/common/Modal";
-import wrapper, { AppDispatch, AppThunk } from "@lib/store/configureStore";
-import { useAppDispatch } from "../lib/slices";
+import { AppDispatch } from "@lib/store/configureStore";
+import { useRouter } from "next/router";
+import { popModal } from "@lib/slices/ModalSlice";
 
 const find = (): ReactElement => {
+  const router = useRouter();
   const { study, last, LoadStudyLoading, selectedCategory } = useSelector((state: RootState) => state.study);
-  const Appdispatch = useAppDispatch();
   const dispatch = useDispatch<AppDispatch>();
   const throttleGetLoadStudy = useMemo(() => _.throttle((param) => dispatch(LoadStudy(param)), 200), [dispatch]);
-  // useEffect(() => {
-  //   window.scrollTo(0, 0);
 
-  //   const lastId = study[study.length - 1]?.id;
-  //   throttleGetLoadStudy({ lastId, categoryName: selectedCategory });
-  // }, []);
   useEffect(() => {
     dispatch(loadUserByToken(null));
     dispatch(LoadStudy({ lastId: null, categoryName: "" }));
@@ -51,6 +47,13 @@ const find = (): ReactElement => {
       window.removeEventListener("scroll", onScroll);
     };
   }, [study, last, LoadStudyLoading, selectedCategory]);
+
+  useEffect(() => {
+    if (router.query.studyId) {
+      dispatch(popModal(null));
+      dispatch(LoadOneStudy({ studyId: parseInt(router.query.studyId as string) }));
+    }
+  }, [router.query.studyId]);
 
   return (
     <>


### PR DESCRIPTION
- 스터디 좋아요를 클릭할 때 로그인되어 있지 않은 사용자인 경우 모달을 제거하고 로그인할 수 있는 페이지로 이동하게 수정했습니다.
- `user` 는 [`initialState`](https://github.com/Gyumong/StudyPot/blob/aecf948c43f983ed58885315f4b4d47f0e4a8457/front/lib/slices/UserSlice.ts#L42) 가 있기 때문에 `user`는 값이 있어 조건문에서 항상 참이기 때문에 불필요한 조건문을 제거했습니다.
- 스터디 관련 라우팅을 변경했습니다.
  - `/find` → `/study`
  - `/study/:studyId` 라우팅 추가
  - 스터디 카드 클릭시 상세 id 푸시